### PR TITLE
Fix with tests is perfect number

### DIFF
--- a/Algorithms.Tests/Algorithms.Tests.fsproj
+++ b/Algorithms.Tests/Algorithms.Tests.fsproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Math\PerfectNumbersTests.fs" />
     <Compile Include="Strings\ZFunctionTests.fs" />
     <Compile Include="Strings\WordOccurrenceTests.fs" />
     <Compile Include="Strings\UpperTests.fs" />

--- a/Algorithms.Tests/Math/PerfectNumbersTests.fs
+++ b/Algorithms.Tests/Math/PerfectNumbersTests.fs
@@ -1,0 +1,25 @@
+namespace Algorithms.Tests.Math
+
+open Microsoft.VisualStudio.TestTools.UnitTesting
+open Algorithms.Math
+
+[<TestClass>]
+type PerfectNumbersTests () =
+    
+    [<TestMethod>]
+    [<DataRow(1, false)>]
+    [<DataRow(2, false)>]
+    [<DataRow(3, false)>]
+    [<DataRow(4, false)>]
+    [<DataRow(5, false)>]
+    [<DataRow(6, true)>]
+    [<DataRow(7, false)>]
+    [<DataRow(27, false)>]
+    [<DataRow(28, true)>]
+    [<DataRow(496, true)>]
+    [<DataRow(8128, true)>]
+    [<DataRow(33550336, true)>]
+    [<DataRow(33550337, false)>]
+    member this.IsPerfect (n: int, expected: bool) =
+        let actual = Perfect_Numbers.IsPerfect n
+        Assert.AreEqual(expected, actual)

--- a/Algorithms/Math/Perfect_Numbers.fs
+++ b/Algorithms/Math/Perfect_Numbers.fs
@@ -3,7 +3,7 @@ namespace Algorithms.Math
 module Perfect_Numbers =
     let IsPerfect (number: int) =
         let total =
-            seq { 1 .. number }
+            seq { 1 .. number - 1 }
             |> Seq.filter (fun n -> number % n = 0)
             |> Seq.sum
 


### PR DESCRIPTION
Fix `Perfect_Numbers.IsPerfect` function excluding the number itself from the sum. Added tests to check its output.