### PR TITLE
Implement algorithm of average (mean) computation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+.idea/

--- a/Algorithms.Tests/Math/AverageTests.fs
+++ b/Algorithms.Tests/Math/AverageTests.fs
@@ -1,0 +1,15 @@
+﻿namespace Algorithms.Tests.Math
+
+open Microsoft.VisualStudio.TestTools.UnitTesting
+open Algorithms.Math
+
+[<TestClass>]
+type AverageTests() =
+
+    [<TestMethod>]
+    member this.Test() =
+        Assert.AreEqual(None, Average.average List.empty<float>)
+        Assert.AreEqual(Some 2.0, Average.average [1.0; 2.0; 3.0])
+        Assert.AreEqual(Some 1.0, Average.average [1.0])
+
+

--- a/Algorithms/Math/Average.fs
+++ b/Algorithms/Math/Average.fs
@@ -1,0 +1,11 @@
+﻿namespace Algorithms.Math
+
+module Average =
+    let inline average (xs: ^a list) =
+        match xs with
+        | [] -> None
+        | _ ->
+            let sum, count = List.fold (fun (sum, count) current -> (sum + current, count + 1))
+                                       (LanguagePrimitives.GenericZero, 0)
+                                       xs
+            LanguagePrimitives.DivideByInt sum count |> Some                              

--- a/Algorithms/Strings/HasPrefix.fs
+++ b/Algorithms/Strings/HasPrefix.fs
@@ -1,3 +1,5 @@
+namespace Algorithms.Strings
+
 module HasPrefix =
     /// <summary>
     /// Reports string has specified prefix or not.

--- a/Algorithms/Strings/HasSuffix.fs
+++ b/Algorithms/Strings/HasSuffix.fs
@@ -1,3 +1,5 @@
+namespace Algorithms.Strings
+
 module HasSuffix =
     /// <summary>
     /// Reports string has specified suffix or not.

--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -4,6 +4,7 @@
   * Math
     * [Absmaxtests](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms.Tests/Math/AbsMaxTests.fs)
     * [Absmintests](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms.Tests/Math/AbsMinTests.fs)
+    * [Averagetests](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms.Tests/Math/AverageTests.fs)
     * [Abstests](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms.Tests/Math/AbsTests.fs)
     * [Factorialtests](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms.Tests/Math/FactorialTests.fs)
     * [Perfectnumberstests](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms.Tests/Math/PerfectNumbersTests.fs)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains algorithms and data structures implemented in F# for ed
     + [Abs](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms/Math/Abs.fs)
     + [Abs Maximum](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms/Math/AbsMax.fs)
     + [Abs Minimum](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms/Math/AbsMin.fs)
+    + [Average](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms/Math/Average.fs)
     + [Factorial](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms/Math/Factorial.fs)
     + [Fibonacci](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms/Math/Fibonacci.fs)
     + [Greatest Common Divisor](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms/Math/Greatest_Common_Divisor.fs)


### PR DESCRIPTION
Append **.idea/** to **.gitignore** to skip JetBrains Rider files from committing.
Append `namespace` clause in header of **HasPrefix.fs**, **HasSuffix.fs** because they didn't compile.
Append generic implementation of `average` function.

Tags: hacktoberfest, first PR