### PR TITLE
Add trie data structure and tests

### DIFF
--- a/Algorithms.Tests/Algorithms.Tests.fsproj
+++ b/Algorithms.Tests/Algorithms.Tests.fsproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
@@ -7,15 +6,14 @@
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Math/*.fs" />
     <Compile Include="Search/*.fs" />
     <Compile Include="Sort/*.fs" />
     <Compile Include="Strings/*.fs" />
+    <Compile Include="DataStructures/*.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
@@ -25,9 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Algorithms\Algorithms.fsproj" />
   </ItemGroup>
-
 </Project>

--- a/Algorithms.Tests/DataStructures/Trie.fs
+++ b/Algorithms.Tests/DataStructures/Trie.fs
@@ -30,19 +30,20 @@ type TrieTests () =
 
     [<TestMethod>]
     member this.``Test insert empty key``() =
-        let mutable trie = empty
+        let trie =
+            empty
+            |> insert ""
 
-        trie <- insert "" trie
         Assert.IsTrue(search "" trie)
         Assert.IsFalse(search "foo" trie)
 
     [<TestMethod>]
     member this.``Test overlapping keys``() =
-        let mutable trie = empty
-
-        trie <- insert "car" trie
-        trie <- insert "cart" trie
-        trie <- insert "carter" trie
+        let trie =
+            empty
+            |> insert "car"
+            |> insert "cart"
+            |> insert "carter"
 
         Assert.IsTrue(search "car" trie)
         Assert.IsTrue(search "cart" trie)
@@ -51,9 +52,10 @@ type TrieTests () =
 
     [<TestMethod>]
     member this.``Test partial match``() =
-        let mutable trie = empty
+        let trie =
+            empty
+            |> insert "apple"
 
-        trie <- insert "apple" trie
         Assert.IsFalse(search "app" trie)
         Assert.IsFalse(search "appl" trie)
         Assert.IsTrue(search "apple" trie)

--- a/Algorithms.Tests/DataStructures/Trie.fs
+++ b/Algorithms.Tests/DataStructures/Trie.fs
@@ -1,0 +1,60 @@
+namespace Algorithms.Tests.DataStructures
+
+open Microsoft.VisualStudio.TestTools.UnitTesting
+open Algorithms.DataStructures.Trie
+
+[<TestClass>]
+type TrieTests () =
+
+    [<TestMethod>]
+    member this.``Test insertion and retrieval with strings``() =
+        let mutable trie = empty
+
+        trie <- insert "foo" trie
+        Assert.IsTrue(search "foo" trie)
+
+        trie <- insert "foobar" trie
+        Assert.IsTrue(search "foobar" trie)
+        Assert.IsTrue(search "foo" trie)
+
+        trie <- insert "bar" trie
+        Assert.IsTrue(search "bar" trie)
+        Assert.IsFalse(search "baz" trie)
+        Assert.IsFalse(search "foobarbaz" trie)
+
+    [<TestMethod>]
+    member this.``Test empty trie``() =
+        let trie = empty
+        Assert.IsFalse(search "foo" trie)
+        Assert.IsFalse(search "" trie)
+
+    [<TestMethod>]
+    member this.``Test insert empty key``() =
+        let mutable trie = empty
+
+        trie <- insert "" trie
+        Assert.IsTrue(search "" trie)
+        Assert.IsFalse(search "foo" trie)
+
+    [<TestMethod>]
+    member this.``Test overlapping keys``() =
+        let mutable trie = empty
+
+        trie <- insert "car" trie
+        trie <- insert "cart" trie
+        trie <- insert "carter" trie
+
+        Assert.IsTrue(search "car" trie)
+        Assert.IsTrue(search "cart" trie)
+        Assert.IsTrue(search "carter" trie)
+        Assert.IsFalse(search "care" trie)
+
+    [<TestMethod>]
+    member this.``Test partial match``() =
+        let mutable trie = empty
+
+        trie <- insert "apple" trie
+        Assert.IsFalse(search "app" trie)
+        Assert.IsFalse(search "appl" trie)
+        Assert.IsTrue(search "apple" trie)
+        Assert.IsFalse(search "applepie" trie)

--- a/Algorithms/Algorithms.fsproj
+++ b/Algorithms/Algorithms.fsproj
@@ -1,22 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Math/*.fs" />
     <Compile Include="Search/*.fs" />
     <Compile Include="Sort/*.fs" />
     <Compile Include="Strings/*.fs" />
+    <Compile Include="DataStructures/*.fs" />
   </ItemGroup>
-
 </Project>

--- a/Algorithms/DataStructures/Trie.fs
+++ b/Algorithms/DataStructures/Trie.fs
@@ -1,0 +1,37 @@
+namespace Algorithms.DataStructures
+
+module Trie =
+
+    type Trie = {
+        IsWord : bool
+        Children : Map<char, Trie>
+    }
+
+    let empty : Trie = { IsWord = false; Children = Map.empty }
+
+    let insert (word: string) (trie: Trie) : Trie =
+        let rec insertImpl (chars: char list) (trie: Trie) : Trie =
+            match chars with
+            | [] ->
+                { trie with IsWord = true }
+            | c :: rest ->
+                match trie.Children.TryFind c with
+                | Some child ->
+                    let child = insertImpl rest child
+                    { trie with Children = trie.Children.Add(c, child) }
+                | None ->
+                    let child = insertImpl rest empty
+                    { trie with Children = trie.Children.Add(c, child) }
+
+        insertImpl (word |> Seq.toList) trie
+
+    let search (word: string) (trie: Trie) : bool =
+        let rec searchImpl (chars: char list) (trie: Trie) : bool =
+            match chars with
+            | [] -> trie.IsWord
+            | c :: rest ->
+                match trie.Children.TryFind c with
+                | Some child -> searchImpl rest child
+                | None -> false
+        searchImpl (word |> Seq.toList) trie
+

--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -1,6 +1,8 @@
 # List of all files
 
 ## Algorithms.Tests
+  * Datastructures
+    * [Trie](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms.Tests/DataStructures/Trie.fs)
   * Math
     * [Absmaxtests](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms.Tests/Math/AbsMaxTests.fs)
     * [Absmintests](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms.Tests/Math/AbsMinTests.fs)
@@ -37,6 +39,8 @@
     * [Zfunctiontests](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms.Tests/Strings/ZFunctionTests.fs)
 
 ## Algorithms
+  * Datastructures
+    * [Trie](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms/DataStructures/Trie.fs)
   * Math
     * [Abs](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms/Math/Abs.fs)
     * [Absmax](https://github.com/TheAlgorithms/F-Sharp/blob/main/Algorithms/Math/AbsMax.fs)


### PR DESCRIPTION
Functional implementation of trie data structure, that is after adding an word, old trie reference is still valid.


Tests are copied from rust implementation of tire. [link](https://github.com/TheAlgorithms/Rust/blob/master/src/data_structures/trie.rs)


